### PR TITLE
Sinister kid patch voidstranger

### DIFF
--- a/loader/main.c
+++ b/loader/main.c
@@ -2977,7 +2977,7 @@ void *pthread_main(void *arg) {
 	if (!strcmp(game_id, "DELTARUNE")) {
 		debugPrintf("Enabling Deltarune specific gamehack!\n");
 		deltarune_hack = 1;
-	else if (!strcmp(game_id, "void_stranger")) {
+	} else if (!strcmp(game_id, "void_stranger")) {
 		debugPrintf("Enabling Void Stranger specific gamehack!\n");
 		voidstranger_hack = 1;
 	}

--- a/loader/main.c
+++ b/loader/main.c
@@ -107,6 +107,7 @@ int get_index = 0;
 int setup_ended = 0;
 
 int deltarune_hack = 0;
+int voidstranger_hack = 0;
 
 extern int (*YYGetInt32) (void *args, int idx);
 void (*Function_Add)(const char *name, intptr_t func, int argc, char ret);
@@ -2584,6 +2585,10 @@ void ReleasePrimitiveArrayCritical(void *env, void *arr, void *carray, int mode)
 
 static void game_end()
 {
+	if (voidstranger_hack) {
+		void (*Run_EndGame) () = (void *)so_symbol(&yoyoloader_mod, "_Z11Run_EndGamev");
+		Run_EndGame();
+	}
 #ifdef STANDALONE_MODE
 	sceKernelExitProcess(0);
 #else
@@ -2972,6 +2977,9 @@ void *pthread_main(void *arg) {
 	if (!strcmp(game_id, "DELTARUNE")) {
 		debugPrintf("Enabling Deltarune specific gamehack!\n");
 		deltarune_hack = 1;
+	else if (!strcmp(game_id, "void_stranger")) {
+		debugPrintf("Enabling Void Stranger specific gamehack!\n");
+		voidstranger_hack = 1;
 	}
 	
 	// Starting the Runner


### PR DESCRIPTION
Added a call to the runner inside game_end implementation. (Void Stranger not-so-hack)
This is needed by Void Stranger game to save without corrupting save file. Just released an optimization patch to make posible to run it on Vita along a modified standalone YoYoLoader vpk but wanted to make it posible play it with regular app.
Don't know if this is the best way to make it, don't like the idea of adding particular game patches, as maybe this should be called if platTarget is set to Windows so GameEnd event is triggered before exit as it does on desktop platforms. But for the case just mimicked the deltarune_hack thing.